### PR TITLE
draft-petithuguenin-behave-turn-uris-08

### DIFF
--- a/rtcweb-uri-schemes/draft-petithuguenin-behave-turn-uris-08.xml
+++ b/rtcweb-uri-schemes/draft-petithuguenin-behave-turn-uris-08.xml
@@ -3,7 +3,7 @@
 <?rfc strict="no" ?>
 <?rfc symrefs="yes" ?>
 <?rfc toc="yes" ?>
-<rfc category="std" docName="draft-petithuguenin-behave-turn-uris-07" ipr="trust200902">
+<rfc category="std" docName="draft-petithuguenin-behave-turn-uris-08" ipr="trust200902">
 	<front>
 		<title abbrev="TURN URIs">Traversal Using Relays around NAT (TURN) Uniform Resource Identifiers</title>
 
@@ -97,7 +97,7 @@
 			</t>
 
 			<t>
-<xref target="RFC5928"/> defines a resolution mechanism to convert a secure flag, a host name or IP address, an eventually empty port, and an eventually empty transport to a list of IP address, port, and TURN transport tuples.</t>
+<xref target="RFC5928"/> defines a resolution mechanism to convert a secure flag, a host name or IP address, a potentially empty port, and a potentially empty transport to a list of IP address, port, and TURN transport tuples.</t>
 
 			<t>To simplify the provisioning of TURN clients, this document defines a TURN and a TURNS URI scheme that can carry the four components needed for the resolution mechanism.</t>
 		</section>
@@ -115,39 +115,18 @@
 
 				<figure>
 					<artwork type="abnf"><![CDATA[
-turnURI       = scheme ":" turn-host [ ":" turn-port ]
+turnURI       = scheme ":" host [ ":" port ]
                 [ "?transport=" transport ]
 scheme        = "turn" / "turns"
 transport     = "udp" / "tcp" / transport-ext
-transport-ext = 1*unreserved
-turn-host     = IP-literal / IPv4address / reg-name
-turn-port     = *DIGIT
-IP-literal    = "[" ( IPv6address / IPvFuture  ) "]"
-IPvFuture     = "v" 1*HEXDIG "." 1*( unreserved / sub-delims / ":" )
-IPv6address   =                              6( h16 ":" ) ls32
-                /                       "::" 5( h16 ":" ) ls32
-                / [               h16 ] "::" 4( h16 ":" ) ls32
-                / [ *1( h16 ":" ) h16 ] "::" 3( h16 ":" ) ls32
-                / [ *2( h16 ":" ) h16 ] "::" 2( h16 ":" ) ls32
-                / [ *3( h16 ":" ) h16 ] "::"    h16 ":"   ls32
-                / [ *4( h16 ":" ) h16 ] "::"              ls32
-                / [ *5( h16 ":" ) h16 ] "::"              h16
-                / [ *6( h16 ":" ) h16 ] "::"
-h16           = 1*4HEXDIG
-ls32          = ( h16 ":" h16 ) / IPv4address
-IPv4address   = dec-octet "." dec-octet "." dec-octet "." dec-octet
-dec-octet     = DIGIT                 ; 0-9
-                / %x31-39 DIGIT       ; 10-99
-                / "1" 2DIGIT          ; 100-199
-                / "2" %x30-34 DIGIT   ; 200-249
-                / "25" %x30-35        ; 250-255
-reg-name      = *( unreserved / pct-encoded / sub-delims )]]>
+transport-ext = 1*unreserved]]>
 					</artwork>
 				</figure>
 
 				<t>
-					&lt;unreserved&gt;, &lt;pct-encoded&gt;, and &lt;sub-delims&gt; are specified in <xref target="RFC3986"/>.
-					The core rules &lt;DIGIT&gt; and &lt;HEXDIGIT&gt; are used as described in Appendix B of RFC 5234 <xref target="RFC5234"/>.
+					&lt;host&gt;, and &lt;port&gt; are specified in <xref target="RFC3986"/>.
+					While these two ABNF productions are defined in <xref target="RFC3986"/> as components of the generic hierarchical URI, this does not imply that that the turn and turns schemes are hierarchical URIs.
+					Developers MUST NOT use a generic hierarchical URI parser to parse a turn or turns URI.
 				</t>
 
 				<t>
@@ -213,12 +192,16 @@ reg-name      = *( unreserved / pct-encoded / sub-delims )]]>
 					<list style="hanging">
 						<t hangText="Organization: ">Google Inc.</t>
 						<t hangText="Name: ">
-							libjingle 0.7.1
+							libjingle revision 4831
 							https://code.google.com/p/chromium/codesearch#chromium/src/third_party/libjingle/source/talk/app/webrtc/peerconnection.cc
 						</t>
 						<t hangText="Description: ">Libjingle is a set of components provided by Google to implement Jingle protocols XEP-166 (http://xmpp.org/extensions/xep-0166.html) and XEP-167 (http://xmpp.org/extensions/xep-0167.html).</t>
 						<t hangText="Level of maturity: ">Beta.</t>
-						<t hangText="Coverage: ">Implements draft-petithuguenin-behave-turn-uris-01 without IPv6.</t>
+						<t hangText="Coverage: ">
+							Implements draft-petithuguenin-behave-turn-uris-07 without IPv6.
+							The turn and turns schemes are parsed, and TLS is used when the secure bit is set.
+							The libjingle library does not use the SRV and NAPTR RR from the RFC 5928 resolution mechanism.
+						</t>
 						<t hangText="Licensing: ">BSD 3-clauses license.</t>
 						<t hangText="Contact: ">https://code.google.com/p/chromium/</t>
 					</list>
@@ -235,7 +218,10 @@ reg-name      = *( unreserved / pct-encoded / sub-delims )]]>
 						</t>
 						<t hangText="Description: ">Mozilla Firefox is a free and open source web browser.</t>
 						<t hangText="Level of maturity: ">Beta.</t>
-						<t hangText="Coverage: ">Implements draft-petithuguenin-behave-turn-uri-03 without RFC 5928.</t>
+						<t hangText="Coverage: ">
+							Implements draft-petithuguenin-behave-turn-uri-03 without RFC 5928.
+							The mozilla code parses the turn and turns schemes but does not seems to use TLS.
+						</t>
 						<t hangText="Licensing: ">Mozilla Public License, v2.0.</t>
 						<t hangText="Contact: ">http://www.mozilla.org/en-US/firefox/channel/</t>
 					</list>
@@ -251,6 +237,12 @@ reg-name      = *( unreserved / pct-encoded / sub-delims )]]>
 
 			<t>The "turn" and "turns" URI schemes do not introduce any specific security issues beyond the security considerations discussed in <xref target="RFC3986"/>.</t>
 
+			<t>
+				While the turn and turns URIs do not themselves include the username or password that will be used to authenticate the TURN client, in certain environments, such as WebRTC, the username and password will almost certainly be provisioned remotely by an external agent at the same time as a turns URI is sent to that client.
+				Thus, in such situations, if the username and password were received in clear there would be little or no benefit to using a turns URI.
+				For this reason a TURN client MUST ensure that the username, password, and turns URI and any other security-relevant parameters are received with equivalent security before using the turns URI.
+				Receiving those parameters over another TLS session can provide the appropriate level of security, if both TLS sessions are similarly parameterised, e.g.  with commensurate strength ciphersuites.
+			</t>
 		</section>
 
 		<section anchor="section.iana" title="IANA Considerations">
@@ -301,14 +293,12 @@ reg-name      = *( unreserved / pct-encoded / sub-delims )]]>
 		<section anchor="section.acknowledgements" title="Acknowledgements">
 			<t>Thanks to Margaret Wasserman, Magnus Westerlund, Juergen Schoenwaelder, Sean Turner, Ted Hardie, Dave Thaler, Alfred E. Heggestad, Eilon Yardeni, Dan Wing, Alfred Hoenes, and Jim Kleck for the comments, suggestions and questions that helped improve the draft-petithuguenin-behave-turn-uri-bis document.</t>
 			<t>Many thanks to Cullen Jennings for his detailed review and thoughtful comments on the draft-nandakumar-rtcweb-turn-uri document.</t>
-			<t>Thanks to Bjoern Hoehrmann, Dan Wing, Russ Housley, S. Moonesamy, Graham Klyne, Harald Alvestrand, Hadriel Kaplan and Tina Tsou for the comments, suggestions and questions that helped improve this document.</t>
+			<t>Thanks to Bjoern Hoehrmann, Dan Wing, Russ Housley, S. Moonesamy, Graham Klyne, Harald Alvestrand, Hadriel Kaplan, Tina Tsou, Spencer Dawkins, Ted Lemon, Barry Leiba, Pete Resnick, and Stephen Farrell for the comments, suggestions and questions that helped improve this document.</t>
 
 			<t>
 				The authors would also like to express their gratitude to Dan Wing for his assistance in shepherding this document.
 				We also want to thank Gonzalo Camarillo, the Real-time Applications and Infrastructure Director, for sponsoring this document as well his careful reviews.
 			</t>
-
-			<t>The &lt;turn-port&gt; and &lt;turn-host&gt; ABNF productions have been copied from the &lt;port&gt; and &lt;host&gt; ABNF productions from <xref target="RFC3986"/>.</t>
 		</section>
 	</middle>
 
@@ -597,11 +587,6 @@ reg-name      = *( unreserved / pct-encoded / sub-delims )]]>
 			<t>
 				<list style="symbols">
 					<t>
-						The ABNF in this document duplicates the &lt;IP-literal&gt;, &lt;IPv4address&gt;, and &lt;reg-name&gt; productions and other dependent productions from <xref target="RFC3986"/>, instead of referencing them.
-						This is because the definitions in RFC 3986 are for hierarchical URIs, so using these references in an opaque URI made reviewers think that a hierarchical URI parser could be used to parse the URIs defined in this document.
-					</t>
-
-					<t>
 						One recurring comment was to stop using the suffix "s" on URI scheme, and to move the secure option to a parameter (e.g. ";proto=tls").
 						We decided against this idea because the STUN URI does not have a ";proto=" parameter and we would have lost the symmetry between the TURN and STUN URIs.
 						A more detailed account of the reasoning behind this is available at &lt;http://blog.marc.petit-huguenin.org/2012/09/on-design-of-stun-and-turn-uri-formats.html&gt;
@@ -622,12 +607,14 @@ reg-name      = *( unreserved / pct-encoded / sub-delims )]]>
 		<section title="Release notes">
 			<t>This section must be removed before publication as an RFC.</t>
 
-			<section title="Modifications between petithuguenin-behave-turn-uris-07 and petithuguenin-behave-turn-uris-06">
+			<section title="Modifications between petithuguenin-behave-turn-uris-08 and petithuguenin-behave-turn-uris-07">
 				<t>
 					<list style="symbols">
-						<t>Updated the applications/protocols entry in the scheme registration form.</t>
-						<t>Merged the first and last paragraphs of the security section.</t>
-						<t>Repeated the description of what turn/turns URIs actually identify in the semantics section so it is reachable from the URI registration.</t>
+						<t>s/eventually/potentially/</t>
+						<t>Changed the ABNF to use references from RFC 3986 instead of copying them.</t>
+						<t>Converted the design note about hierarchical parsers into a MUST NOT statement.</t>
+						<t>Updated the RFC 6982 forms for Chrome and Firefox.</t>
+						<t>Added text in security section about verifying that username, password and uris are received over a secure connection.</t>
 					</list>
 				</t>
 			</section>


### PR DESCRIPTION
-  s/eventually/potentially/
-  Changed the ABNF to use references from RFC 3986 instead of
  copying them.
-  Converted the design note about hierarchical parsers into a MUST
  NOT statement.
-  Updated the RFC 6982 forms for Chrome and Firefox.
-  Added text in security section about verifying that username,
  password and uris are received over a secure connection.
